### PR TITLE
[codex] fix renovate release age policy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,14 @@
 	"pre-commit": {
 		"enabled": true
 	},
+	"dependencyDashboard": true,
+	"internalChecksFilter": "strict",
+	"prCreation": "not-pending",
+	"packageRules": [
+		{
+			"matchDatasources": ["npm"],
+			"minimumReleaseAge": "2 days"
+		}
+	],
 	"schedule": ["monthly"]
 }


### PR DESCRIPTION
## Summary

- Add Renovate npm `minimumReleaseAge` of 2 days.
- Require Renovate internal checks to pass before PR creation.
- Enable the dependency dashboard so delayed updates are visible.

## Why

pnpm rejects lockfile entries that are newer than the active supply-chain policy cutoff. Renovate can show package age rounded to `1d` while the exact publish time is still inside pnpm's 24h minimum release age window, causing dependency PR CI to fail during `pnpm install --frozen-lockfile`.

## Validation

- `renovate.json` parsed as valid JSON locally.
- `pnpm install --frozen-lockfile` passed locally after network access was allowed: `Lockfile passes supply-chain policies`.
